### PR TITLE
:sparkles: Return callback on addWindowMetricsListener

### DIFF
--- a/src/chayns/calls/getWindowMetrics.js
+++ b/src/chayns/calls/getWindowMetrics.js
@@ -168,6 +168,8 @@ export function addWindowMetricsListener(cb, startCall = false) {
     if (startCall) {
         _getWindowMetricsCallback();
     }
+
+    return cb;
 }
 
 export function removeWindowMetricsListener(cb) {


### PR DESCRIPTION
It would be easier to remove the listener afterwards, especially with React hooks.