### PR TITLE
Select dialog config

### DIFF
--- a/src/chayns/calls/dialogs/select.js
+++ b/src/chayns/calls/dialogs/select.js
@@ -58,6 +58,7 @@ export function select(config) {
             'quickfind': !!config.quickfind,
             'type': config.type,
             'preventCloseOnClick': !!config.preventCloseOnClick,
+            'selectAllButton': config.selectAllButton,
             list
         });
     }


### PR DESCRIPTION
Add config for a selectAllButton to toggle the selectList of a the select dialog.

This config value is needed for the dialog.js to show a togglButton for the select list.